### PR TITLE
Remove exceed emit

### DIFF
--- a/contracts/interfaces/IDiamondCut.sol
+++ b/contracts/interfaces/IDiamondCut.sol
@@ -27,6 +27,4 @@ interface IDiamondCut {
         address _init,
         bytes calldata _calldata
     ) external;
-
-    event DiamondCut(FacetCut[] _diamondCut, address _init, bytes _calldata);
 }

--- a/contracts/libraries/LibDiamond.sol
+++ b/contracts/libraries/LibDiamond.sol
@@ -51,8 +51,6 @@ library LibDiamond {
         require(msg.sender == diamondStorage().contractOwner, "LibDiamond: Must be contract owner");
     }
 
-    event DiamondCut(IDiamondCut.FacetCut[] _diamondCut, address _init, bytes _calldata);
-
     // Internal function version of diamondCut
     function diamondCut(
         IDiamondCut.FacetCut[] memory _diamondCut,
@@ -71,7 +69,6 @@ library LibDiamond {
                 revert("LibDiamondCut: Incorrect FacetCutAction");
             }
         }
-        emit DiamondCut(_diamondCut, _init, _calldata);
         initializeDiamondCut(_init, _calldata);
     }
 

--- a/test/cacheBugTest.js
+++ b/test/cacheBugTest.js
@@ -7,6 +7,8 @@ const { FacetCutAction } = require('../scripts/libraries/diamond.js')
 
 const { assert } = require('chai')
 
+const hre = require('hardhat')
+
 // The diamond example comes with 8 function selectors
 // [cut, loupe, loupe, loupe, loupe, erc165, transferOwnership, owner]
 // This bug manifests if you delete something from the final
@@ -28,6 +30,8 @@ describe('Cache bug test', async () => {
   const sel8 = '0xcbb835f9' // fills up slot 2
   const sel9 = '0xcbb835fa' // fills up slot 2
   const sel10 = '0xcbb835fb' // fills up slot 2
+
+  const diamondGasLimit = Math.floor(800000 * hre.network.config.gasMultiplier)
 
   before(async function () {
     let tx
@@ -61,7 +65,7 @@ describe('Cache bug test', async () => {
         action: FacetCutAction.Add,
         functionSelectors: selectors
       }
-    ], ethers.constants.AddressZero, '0x', { gasLimit: 800000 })
+    ], ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)
@@ -80,7 +84,7 @@ describe('Cache bug test', async () => {
         action: FacetCutAction.Remove,
         functionSelectors: selectors
       }
-    ], ethers.constants.AddressZero, '0x', { gasLimit: 800000 })
+    ], ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)

--- a/test/diamondTest.js
+++ b/test/diamondTest.js
@@ -11,6 +11,8 @@ const { deployDiamond } = require('../scripts/deploy.js')
 
 const { assert } = require('chai')
 
+const hre = require('hardhat')
+
 describe('DiamondTest', async function () {
   let diamondAddress
   let diamondCutFacet
@@ -20,6 +22,8 @@ describe('DiamondTest', async function () {
   let receipt
   let result
   const addresses = []
+
+  const diamondGasLimit = Math.floor(800000 * hre.network.config.gasMultiplier)
 
   before(async function () {
     diamondAddress = await deployDiamond()
@@ -79,7 +83,7 @@ describe('DiamondTest', async function () {
         action: FacetCutAction.Add,
         functionSelectors: selectors
       }],
-      ethers.constants.AddressZero, '0x', { gasLimit: 800000 })
+      ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)
@@ -103,7 +107,7 @@ describe('DiamondTest', async function () {
         action: FacetCutAction.Replace,
         functionSelectors: selectors
       }],
-      ethers.constants.AddressZero, '0x', { gasLimit: 800000 })
+      ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)
@@ -124,7 +128,7 @@ describe('DiamondTest', async function () {
         action: FacetCutAction.Add,
         functionSelectors: selectors
       }],
-      ethers.constants.AddressZero, '0x', { gasLimit: 800000 })
+      ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)
@@ -143,7 +147,7 @@ describe('DiamondTest', async function () {
         action: FacetCutAction.Remove,
         functionSelectors: selectors
       }],
-      ethers.constants.AddressZero, '0x', { gasLimit: 800000 })
+      ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)
@@ -162,7 +166,7 @@ describe('DiamondTest', async function () {
         action: FacetCutAction.Remove,
         functionSelectors: selectors
       }],
-      ethers.constants.AddressZero, '0x', { gasLimit: 800000 })
+      ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)
@@ -184,7 +188,7 @@ describe('DiamondTest', async function () {
         action: FacetCutAction.Remove,
         functionSelectors: selectors
       }],
-      ethers.constants.AddressZero, '0x', { gasLimit: 800000 })
+      ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)
@@ -225,7 +229,7 @@ describe('DiamondTest', async function () {
         functionSelectors: getSelectors(Test2Facet)
       }
     ]
-    tx = await diamondCutFacet.diamondCut(cut, ethers.constants.AddressZero, '0x', { gasLimit: 8000000 })
+    tx = await diamondCutFacet.diamondCut(cut, ethers.constants.AddressZero, '0x', { gasLimit: diamondGasLimit })
     receipt = await tx.wait()
     if (!receipt.status) {
       throw Error(`Diamond upgrade failed: ${tx.hash}`)


### PR DESCRIPTION
I've prepared this PR to enable the use of Diamond contracts on Neon EVM (https://neon-labs.org) - an Ethereum Virtual Machine on Solana.

The main changes are to remove the generation of an extra event that only duplicates the input parameters without any additional information.

We can solve this problem on the Neon EVM side, but as a result, this will increase the cost of transactions.

We think removing this event would be beneficial to other Ehtereum-like blockchains too, because events are increase the cost of txs

https://github.com/ethereum/go-ethereum/blob/master/params/protocol_params.go
```
LogDataGas   uint64 = 8     // Per byte in a LOG* operation's data.
LogGas       uint64 = 375   // Per LOG* operation.
LogTopicGas  uint64 = 375   
MemoryGas    uint64 = 3
```

 If you approve this PR, I will send you the same changes to other 2 variants of Diamond contract.